### PR TITLE
CCFRI-5191: Add the 'CCOF - Super Awesome Mods Squad' security role

### DIFF
--- a/CCOF.Infrastructure.Plugins/FundingAgreement/RestrictFundingStatus.cs
+++ b/CCOF.Infrastructure.Plugins/FundingAgreement/RestrictFundingStatus.cs
@@ -121,6 +121,7 @@ namespace CCOF.Infrastructure.Plugins.FundingAgreement
                         var allowedRoles = new List<string> { "System Administrator",
                                                               "CCOF - Admin",
                                                               "CCOF - Leadership",
+                                                              "CCOF - Super Awesome Mods Squad",															  
                                                               "CCOF - Mod QC",
                                                               "CCOF - QC",
                                                               "CCOF - Sr. Adjudicator",


### PR DESCRIPTION
 - In response to the client update on confluence page, added the 'CCOF - Super Awesome Mods Squad' security role